### PR TITLE
fix anchor navigation links

### DIFF
--- a/app/content/archive.mdx
+++ b/app/content/archive.mdx
@@ -18,11 +18,11 @@ One of the biggest problems we have at ZK Email (and one of the biggest problems
 So we set out to create the largest registry of such keys, and here's how we did it. Note that nearly all the discussion and engineering [happened over open source Github issues](https://github.com/zkemail/archive.prove.email/issues), so definitely search there for more details.
 
 **Table of Contents**<br/>
-[Getting Selectors](#Getting-Selectors)<br/>
-[The Scrape](#The-Scrape)<br/>
-[The Hack](#The-Hack)<br/>
-[The Reverse Engineer](#The-Reverse-Engineer)<br/>
-[The Future](#The-Future)<br/>
+[Getting Selectors](#getting-selectors)<br/>
+[The Scrape](#the-scrape)<br/>
+[The Hack](#the-hack)<br/>
+[The Reverse Engineer](#the-reverse-engineer)<br/>
+[The Future](#the-future)<br/>
 
 ## Getting Selectors
 


### PR DESCRIPTION
anchor links in toc dont work because they start with a capital letter